### PR TITLE
Got rid of public fields 'origin' and 'rotation' in Frame3f.

### DIFF
--- a/math/Frame3f.cs
+++ b/math/Frame3f.cs
@@ -9,8 +9,8 @@ namespace g3
     [Serializable]
     public struct Frame3f
     {
-        public Quaternionf rotation;
-        public Vector3f origin;
+        private Quaternionf rotation;
+        private Vector3f origin;
 
         static readonly public Frame3f Identity = new Frame3f(Vector3f.Zero, Quaternionf.Identity);
 


### PR DESCRIPTION
Got rid of public fields 'origin' and 'rotation' in Frame3f.
When both property 'Rotation' and field 'rotation' are public - NewtonsoftJson serializer makes crazy on initialization, so Frame3f cannot be serialized by default. Nothing to say about the fact that fields should be private when they are facaded by public fields.